### PR TITLE
plugin: React-Query for Data Fetching

### DIFF
--- a/apps/expo/app/(main)/index.tsx
+++ b/apps/expo/app/(main)/index.tsx
@@ -1,3 +1,3 @@
-import HomeScreen from '@app/core/screens/HomeScreen'
+import HomeScreen from '@app/core/routes/index'
 
 export default HomeScreen

--- a/apps/next/app/(main)/page.tsx
+++ b/apps/next/app/(main)/page.tsx
@@ -1,4 +1,4 @@
 'use client'
-import HomeScreen from '@app/core/screens/HomeScreen'
+import HomeScreen from '@app/core/routes/index'
 
 export default HomeScreen

--- a/features/app-core/context/UniversalQueryClientProvider.tsx
+++ b/features/app-core/context/UniversalQueryClientProvider.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+/* --- Constants ------------------------------------------------------------------------------- */
+
+let clientSideQueryClient: QueryClient | undefined = undefined
+
+/** --- makeQueryClient() ---------------------------------------------------------------------- */
+/** -i- Build a queryclient to be used either client-side or server-side */
+export const makeQueryClient = () => {
+    const oneMinute = 1000 * 60
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                // With SSR, we usually want to set some default staleTime
+                // above 0 to avoid refetching immediately on the client
+                staleTime: oneMinute,
+            },
+        },
+    })
+    return queryClient
+}
+
+/** --- getQueryClient() ----------------------------------------------------------------------- */
+/** -i- Always makes a new query client on the server, but reuses an existing client if found in browser or mobile */
+export const getQueryClient = () => {
+    // Always create a new query client on the server, so no caching is shared between requests
+    const isServer = typeof window === 'undefined'
+    if (isServer) return makeQueryClient()
+    // On the browser or mobile, make a new client if we don't already have one
+    // This is important so we don't re-make a new client if React suspends during initial render.
+    // Might not be needed if we have a suspense boundary below the creation of the query client though.
+    if (!clientSideQueryClient) clientSideQueryClient = makeQueryClient()
+    return clientSideQueryClient
+}
+
+/** --- <UniversalQueryClientProvider/> ----------------------------------------------------------------- */
+/** -i- Provides a universal queryclient to be used either client-side or server-side */
+export const UniversalQueryClientProvider = ({ children }: { children: React.ReactNode }) => {
+    const queryClient = getQueryClient()
+    return (
+        <QueryClientProvider client={queryClient}>
+            {children}
+        </QueryClientProvider>
+    )
+}

--- a/features/app-core/navigation/UniversalRouteScreen.helpers.ts
+++ b/features/app-core/navigation/UniversalRouteScreen.helpers.ts
@@ -1,0 +1,59 @@
+'use client'
+import type { Query, QueryKey } from '@tanstack/react-query'
+import { queryBridge } from '../screens/HomeScreen'
+
+/* --- Types ----------------------------------------------------------------------------------- */
+
+export type QueryFn = (args: Record<string, unknown>) => Promise<Record<string, unknown>>
+
+export type QueryBridgeConfig<Fetcher extends QueryFn> = {
+    /** -i- Function to turn any route params into the query key for the `routeDataFetcher()` query */
+    routeParamsToQueryKey: (routeParams: Partial<Parameters<Fetcher>[0]>) => QueryKey
+    /** -i- Function to turn any route params into the input args for the `routeDataFetcher()` query */
+    routeParamsToQueryInput: (routeParams: Partial<Parameters<Fetcher>[0]>) => Parameters<Fetcher>[0]
+    /** -i- Fetcher to prefetch data for the Page and QueryClient during SSR, or fetch it clientside if browser / mobile */
+    routeDataFetcher: Fetcher
+    /** -i- Function transform fetcher data into props */
+    fetcherDataToProps?: (data: Awaited<ReturnType<Fetcher>>) => Record<string, unknown>
+    /** -i- Initial data provided to the QueryClient */
+    initialData?: ReturnType<Fetcher>
+}
+
+export type UniversalRouteProps<Fetcher extends QueryFn> = {
+    /** -i- Optional params passed by the Next.js app router, in Expo we get these from `useRouteParams()` */
+    params?: Partial<Parameters<Fetcher>[0]>
+    /** -i- Optional search params passed by the Next.js app router, in Expo we get these from `useRouteParams()` */
+    searchParams?: Partial<Parameters<Fetcher>[0]>
+    /** -i- Configuration for the query bridge */
+    queryBridge: QueryBridgeConfig<Fetcher>
+    /** -i- The screen to render for this route */
+    routeScreen: React.ComponentType
+}
+
+export type HydratedRouteProps<
+    QueryBridge extends QueryBridgeConfig<QueryFn>
+> = ReturnType<QueryBridge['fetcherDataToProps']> & {
+    /** -i- The route key for the query */
+    queryKey: QueryKey
+    /** -i- The input args for the query */
+    queryInput: Parameters<QueryBridge['routeDataFetcher']>[0]
+    /** -i- The route params passed by the Next.js app router, in Expo we get these from `useRouteParams()` */
+    params: Partial<Parameters<QueryBridge['routeDataFetcher']>[0]>
+    /** -i- The search params passed by the Next.js app router, in Expo we get these from `useRouteParams()` */
+    searchParams: Partial<Parameters<QueryBridge['routeDataFetcher']>[0]>
+}
+
+/** --- createQueryBridge() -------------------------------------------------------------------- */
+/** -i- Util to create a typed bridge between a fetcher and a route's props */
+export const createQueryBridge = <QueryBridge extends QueryBridgeConfig<QueryFn>>(
+    queryBridge: QueryBridge
+) => {
+    type FetcherData = Awaited<ReturnType<QueryBridge['routeDataFetcher']>>
+    type ReturnTypeOfFunction<F, A> = F extends ((args: A) => infer R) ? R : FetcherData
+    type RoutePropsFromFetcher = ReturnTypeOfFunction<QueryBridge['fetcherDataToProps'], FetcherData>
+    const fetcherDataToProps = queryBridge.fetcherDataToProps || ((data: FetcherData) => data)
+    return {
+        ...queryBridge,
+        fetcherDataToProps: fetcherDataToProps as ((data: FetcherData) => RoutePropsFromFetcher),
+    }
+}

--- a/features/app-core/navigation/UniversalRouteScreen.tsx
+++ b/features/app-core/navigation/UniversalRouteScreen.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { useQuery } from '@tanstack/react-query'
+import type { UniversalRouteProps, QueryFn } from './UniversalRouteScreen.helpers'
+import { useRouteParams } from './useRouteParams'
+
+/** --- <UniversalRouteScreen/> -------------------------------------------------------------------- */
+/** -i- Universal Route Wrapper to provide query data on mobile, the browser and during server rendering */
+export const UniversalRouteScreen = <Fetcher extends QueryFn>(props: UniversalRouteProps<Fetcher>) => {
+    // Props
+    const { params: routeParams, searchParams, queryBridge, routeScreen: RouteScreen, ...screenProps } = props
+    const { routeParamsToQueryKey, routeParamsToQueryInput, routeDataFetcher } = queryBridge
+    const fetcherDataToProps = queryBridge.fetcherDataToProps || ((data: ReturnType<Fetcher>) => data)
+
+    // Hooks
+    const expoRouterParams = useRouteParams(props)
+
+    // Vars
+    const queryParams = { ...routeParams, ...searchParams, ...expoRouterParams }
+    const queryKey = routeParamsToQueryKey(queryParams)
+    const queryInput = routeParamsToQueryInput(queryParams)
+
+    // -- Query --
+
+    const queryConfig = {
+        queryKey,
+        queryFn: async () => await routeDataFetcher(queryInput),
+        initialData: queryBridge.initialData,
+    }
+
+    // -- Mobile --
+    
+    const { data: fetcherData } = useQuery(queryConfig)
+    const routeDataProps = fetcherDataToProps(fetcherData) as Record<string, unknown>
+
+    return (
+        <RouteScreen
+            {...routeDataProps}
+            queryKey={queryKey}
+            queryInput={queryInput}
+            {...screenProps} // @ts-ignore
+            params={routeParams}
+            searchParams={searchParams}
+        />
+    )
+}

--- a/features/app-core/navigation/UniversalRouteScreen.web.tsx
+++ b/features/app-core/navigation/UniversalRouteScreen.web.tsx
@@ -1,0 +1,116 @@
+'use client'
+import { use, useState, useEffect } from 'react'
+import { useQueryClient, useQuery, dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import type { UniversalRouteProps, QueryFn } from './UniversalRouteScreen.helpers'
+import { useRouteParams } from './useRouteParams'
+
+/* --- Helpers --------------------------------------------------------------------------------- */
+
+const getSSRData = () => {
+    const $ssrData = document.getElementById('ssr-data')
+    const ssrDataText = $ssrData?.getAttribute('data-ssr')
+    const ssrData = ssrDataText ? (JSON.parse(ssrDataText) as Record<string, any>) : null
+    return ssrData
+}
+
+const getDehydratedSSRState = () => {
+    const $ssrHydrationState = document.getElementById('ssr-hydration-state')
+    const ssrHydrationStateText = $ssrHydrationState?.getAttribute('data-ssr')
+    const ssrHydrationState = ssrHydrationStateText ? (JSON.parse(ssrHydrationStateText) as Record<string, any>) : null
+    return ssrHydrationState
+}
+
+/** --- <UniversalRouteScreen/> ---------------------------------------------------------------- */
+/** -i- Universal Route Wrapper to provide query data on mobile, the browser and during server rendering */
+export const UniversalRouteScreen = <Fetcher extends QueryFn>(props: UniversalRouteProps<Fetcher>) => {
+    // Props
+    const { params: routeParams, searchParams, queryBridge, routeScreen: RouteScreen, ...screenProps } = props
+    const { routeParamsToQueryKey, routeParamsToQueryInput, routeDataFetcher } = queryBridge
+    const fetcherDataToProps = queryBridge.fetcherDataToProps || ((data: ReturnType<Fetcher>) => data)
+
+    // Hooks
+    const nextRouterParams = useRouteParams(props)
+
+    // Context
+    const queryClient = useQueryClient()
+
+    // State
+    const [hydratedData, setHydratedData] = useState<Record<string, any> | null>(null)
+    const [hydratedQueries, setHydratedQueries] = useState<Record<string, any> | null>(null)
+
+    // Vars
+    const isBrowser = typeof window !== 'undefined'
+    const queryParams = { ...routeParams, ...searchParams, ...nextRouterParams }
+    const queryKey = routeParamsToQueryKey(queryParams)
+    const queryInput = routeParamsToQueryInput(queryParams)
+
+    // -- Effects --
+
+    useEffect(() => {
+        const ssrData = getSSRData()
+        if (ssrData) setHydratedData(ssrData) // Save the SSR data to state, removing the SSR data from the DOM
+        const hydratedQueyClientState = getDehydratedSSRState()
+        if (hydratedQueyClientState) setHydratedQueries(hydratedQueyClientState) // Save the hydrated state to state, removing the hydrated state from the DOM
+    }, [])
+
+    // -- Query --
+
+    const queryConfig = {
+        queryKey,
+        queryFn: async () => await routeDataFetcher(queryInput),
+        initialData: queryBridge.initialData,
+    }
+    
+    // -- Browser --
+
+    if (isBrowser) {
+        const hydrationData = hydratedData || getSSRData()
+        const hydrationState = hydratedQueries || getDehydratedSSRState()
+        const renderHydrationData = !!hydrationData && !hydratedData // Only render the hydration data if it's not already in state
+
+        const { data: fetcherData } = useQuery({
+            ...queryConfig,
+            initialData: {
+                ...queryConfig.initialData,
+                ...hydrationData,
+            },
+        })
+        const routeDataProps = fetcherDataToProps(fetcherData as Awaited<ReturnType<Fetcher>>) as Record<string, unknown> // prettier-ignore
+
+        return (
+            <HydrationBoundary state={hydrationState}>
+                {renderHydrationData && <div id="ssr-data" data-ssr={JSON.stringify(fetcherData)} />}
+                {renderHydrationData && <div id="ssr-hydration-state" data-ssr={JSON.stringify(hydrationState)} />}
+                <RouteScreen
+                    {...routeDataProps}
+                    queryKey={queryKey}
+                    queryInput={queryInput}
+                    {...screenProps} // @ts-ignore
+                    params={routeParams}
+                    searchParams={searchParams}
+                />
+            </HydrationBoundary>
+        )
+    }
+
+    // -- Server --
+
+    const fetcherData = use(queryClient.fetchQuery(queryConfig)) as Awaited<ReturnType<Fetcher>>
+    const routeDataProps = fetcherDataToProps(fetcherData) as Record<string, unknown>
+    const dehydratedState = dehydrate(queryClient)
+    
+    return (
+        <HydrationBoundary state={dehydratedState}>
+            {!!fetcherData && <div id="ssr-data" data-ssr={JSON.stringify(fetcherData)} />}
+            {!!dehydratedState && <div id="ssr-hydration-state" data-ssr={JSON.stringify(dehydratedState)} />}
+            <RouteScreen
+                {...routeDataProps}
+                queryKey={queryKey}
+                queryInput={queryInput}
+                {...screenProps} // @ts-ignore
+                params={routeParams}
+                searchParams={searchParams}
+            />
+        </HydrationBoundary>
+    )
+}

--- a/features/app-core/package.json
+++ b/features/app-core/package.json
@@ -2,7 +2,9 @@
   "name": "@app/core",
   "version": "1.0.0",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "@tanstack/react-query": "^5.29.2"
+  },
   "devDependencies": {
     "typescript": "5.3.3"
   },

--- a/features/app-core/resolvers/healthCheck.fetcher.ts
+++ b/features/app-core/resolvers/healthCheck.fetcher.ts
@@ -1,0 +1,15 @@
+import type { HealthCheckArgs, HealthCheckResponse } from './healthCheck'
+import { appConfig } from '../appConfig'
+
+/** --- healthCheckFetcher() ------------------------------------------------------------------- */
+/** -i- Isomorphic fetcher for our healthCheck() resolver at '/api/health' */
+export const healthCheckFetcher = async (args: HealthCheckArgs) => {
+    const response = await fetch(`${appConfig.backendURL}/api/health?echo=${args.echo}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+    const data = await response.json()
+    return data as HealthCheckResponse
+}

--- a/features/app-core/resolvers/healthCheck.fetcher.web.ts
+++ b/features/app-core/resolvers/healthCheck.fetcher.web.ts
@@ -1,0 +1,35 @@
+import type { NextRequest, NextResponse } from 'next/server'
+import type { HealthCheckArgs, HealthCheckResponse } from './healthCheck'
+import { appConfig } from '../appConfig'
+
+/** --- healthCheckFetcher() ------------------------------------------------------------------- */
+/** -i- Isomorphic fetcher for our healthCheck() resolver at '/api/health' */
+export const healthCheckFetcher = async (args: HealthCheckArgs) => {
+    // Vars
+    const isServer = typeof window === 'undefined'
+
+    // -- Browser --
+
+    if (!isServer) {
+        const response = await fetch(`${appConfig.backendURL}/api/health?echo=${args.echo}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        })
+        const data = await response.json()
+        return data as HealthCheckResponse
+    }
+
+    // -- Server --
+
+    const { healthCheck } = await import('./healthCheck')
+    const data = await healthCheck({
+        args,
+        context: {
+            req: {} as NextRequest,
+            res: {} as NextResponse,
+        },
+    })
+    return data as HealthCheckResponse
+}

--- a/features/app-core/resolvers/healthCheck.ts
+++ b/features/app-core/resolvers/healthCheck.ts
@@ -9,13 +9,41 @@ const ALIVE_SINCE = new Date()
 
 /* --- Types ----------------------------------------------------------------------------------- */
 
-type HealthCheckArgs = {
+export type HealthCheckArgs = {
   echo?: string
 }
 
-type HealthCheckInputs = {
+export type HealthCheckInputs = {
   args: HealthCheckArgs,
   context: RequestContext
+}
+
+export type HealthCheckResponse = {
+  echo?: string
+  status: 'OK'
+  alive: boolean
+  kicking: boolean
+  now: string
+  aliveTime: number
+  aliveSince: string
+  serverTimezone: string
+  requestHost: string
+  requestProtocol: string
+  requestURL: string
+  baseURL: string
+  backendURL: string
+  apiURL: string
+  graphURL: string
+  port: number | null
+  debugPort: number | null
+  nodeVersion: string
+  v8Version: string
+  systemArch: string
+  systemPlatform: string
+  systemRelease: string
+  systemFreeMemory: number
+  systemTotalMemory: number
+  systemLoadAverage: number[]
 }
 
 /** --- healthCheck() -------------------------------------------------------------------------- */

--- a/features/app-core/routes/index.tsx
+++ b/features/app-core/routes/index.tsx
@@ -1,0 +1,12 @@
+import { UniversalRouteScreen } from '../navigation/UniversalRouteScreen'
+import HomeScreen, { queryBridge } from '../screens/HomeScreen'
+
+/* --- / --------------------------------------------------------------------------------------- */
+
+export default (props: any) => (
+    <UniversalRouteScreen
+        {...props}
+        routeScreen={HomeScreen}
+        queryBridge={queryBridge}
+    />
+)

--- a/features/app-core/screens/HomeScreen.tsx
+++ b/features/app-core/screens/HomeScreen.tsx
@@ -2,10 +2,30 @@ import React from 'react'
 import { StyleSheet, Text, View } from 'react-native'
 import { Link } from '../navigation/Link'
 import { Image } from '../components/Image'
+import { healthCheckFetcher } from '../resolvers/healthCheck.fetcher'
+import { HydratedRouteProps, createQueryBridge } from '../navigation/UniversalRouteScreen.helpers'
+
+/* --- Data Fetching --------------------------------------------------------------------------- */
+
+export const queryBridge = createQueryBridge({
+  routeParamsToQueryKey: (routeParams: { echo: string }) => ['healthCheck', routeParams.echo],
+  routeParamsToQueryInput: (routeParams: { echo: string }) => ({ echo: routeParams.echo }),
+  routeDataFetcher: healthCheckFetcher,
+  fetcherDataToProps: (fetcherData: Awaited<ReturnType<typeof healthCheckFetcher>>) => ({
+    serverHealth: fetcherData
+  }),
+})
+
+queryBridge['fetcherDataToProps']
 
 /* --- <HomeScreen/> --------------------------------------------------------------------------- */
 
-const HomeScreen = () => {
+const HomeScreen = (props: HydratedRouteProps<typeof queryBridge>) => {
+  // Props
+  const { serverHealth } = props
+
+  // -- Render --
+
   return (
     <View style={styles.container}>
       <Image src={require('../assets/aetherspaceLogo.png')} width={60} height={60} style={{ marginBottom: 12 }} />
@@ -13,6 +33,11 @@ const HomeScreen = () => {
       <Text style={styles.subtitle}>Open HomeScreen.tsx in features/app-core/screens to start working on your app</Text>
       <Link href="/subpages/aetherspace" style={styles.link}>Test navigation</Link>
       <Link href="/images" style={styles.link}>Test images</Link>
+      {serverHealth ? (
+        <Link href={`${serverHealth.apiURL}/health?echo=${serverHealth.echo}`} target="_blank" style={styles.link}>Test API</Link>
+      ) : (
+        <Text style={{ ...styles.link,  }}>{'Loading server health...'}</Text>
+      )}
       <Link href="https://universal-base-starter-docs.vercel.app/" target="_blank" style={styles.link}>Docs</Link>
     </View>
   )

--- a/features/app-core/screens/UniversalAppProviders.tsx
+++ b/features/app-core/screens/UniversalAppProviders.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React from 'react'
+import { UniversalQueryClientProvider } from '../context/UniversalQueryClientProvider'
 
 // -i- This is a regular react client component
 // -i- Use this file for adding universal app providers
@@ -15,9 +16,9 @@ type UniversalAppProvidersProps = {
 /* --- <UniversalAppProviders/> ---------------------------------------------------------------- */
 
 const UniversalAppProviders = ({ children }: UniversalAppProvidersProps) => (
-    <>
+    <UniversalQueryClientProvider>
         {children}
-    </>
+    </UniversalQueryClientProvider>
 )
 
 /* --- Exports --------------------------------------------------------------------------------- */

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,9 @@
     "features/app-core": {
       "name": "@app/core",
       "version": "1.0.0",
+      "dependencies": {
+        "@tanstack/react-query": "^5.29.2"
+      },
       "devDependencies": {
         "typescript": "5.3.3"
       }
@@ -6484,6 +6487,30 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.29.0.tgz",
+      "integrity": "sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.29.2.tgz",
+      "integrity": "sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.29.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@types/cookie": {


### PR DESCRIPTION
## Plugin features when merged

- [x] Install and set up `@tanstack/react-query` for use on Browser, Mobile and Serverside
- [x] Use `@tanstack/react-query` to create a `UniversalRouteScreen` wrapper for data fetching everywhere

## Recommended workflow

![Graph showing the Unversal Route Screen component using a fetcher with React-Query to retrieve the props for a RouteComponent before rendering on Web, iOS and Android](https://github.com/user-attachments/assets/d64fbf93-4a35-433e-91c7-10d6bdf1a0ab)

### 1. Start with component & bridge in `/screens/` folder

`SomeScreen.tsx`

```tsx
import { someFetcher } from '../resolvers/some.fetcher'
import { createQueryBridge, HydratedRouteProps } from '../navigation/UniversalRouteScreen.helpers'

/* --- Data Fetching ----------- */

// -i- Think of a "bridge" as a universal version of `getServerSideProps()` from next.js
// -i- ...which will work on Expo / Mobile / iOS / Android as well as on server / browser
const queryBridge = createQueryBridge({

    // Transform the route params into things useable by react-query
    routeParamsToQueryKey: (routeParams) => ['subpage', routeParams.slug],
    routeParamsToQueryInput: (routeParams) => ({ slug: routeParams.slug }),

    // Provide the fetcher function to be used by react-query
    routeDataFetcher: someFetcher,

    // Transform fetcher output to props after react-query was called
    fetcherDataToProps: (fetcherData) => ({ someProp: fetcherData }),
})

/* --- <SomeScreen/> ----------- */

// Component for screen UI can infer types from "bridge" 👇
const SomeScreen = (props: HydratedRouteProps<typeof queryBridge>) => {
    
    // Props with inferred types 🙌
    const { someProp } = props
    
    // Render screen UI
    // ...
}
```

### 2. Use bridge & component in workspace `/routes/` folder

`/routes/subpages/[slug]/index.ts` -- in e.g. the `@app/core` workspace

```tsx
import { SomeScreen, queryBridge } from '@app/screens/SomeScreen'
import { UniversalRouteScreen } from '@app/navigation'

/* --- /subpages/[slug] ----------- */

export default (props) => (
    <UniversalRouteScreen
        {...props}
        // Will execute each step from the bridge in sequence to get to the final props
        queryBridge={queryBridge}
        // Will provide the final props to the screen component on iOS, Android, server & browser
        routeScreen={SomeScreen}
    />
)
```

> 💡 The reason we define the route in a workspace is so we can re-use this file in both Expo & Next.js 👇

### 3. Reexport route file in Expo & Next.js app routers

`app/subpages/[slug]/index.ts` in `@app/expo` workspace

```tsx
import SlugRoute from '@app/routes/subpages/[slug]'

export default SlugRoute
```

`app/subpages/[slug]/page.ts` in `@app/next` workspace

```tsx
import SlugRoute from '@app/routes/subpages/[slug]'

export default SlugRoute

// -i- Export any other next.js routing config here
// -i- See: https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config

export const dynamic = 'auto'
export const dynamicParams = true
export const revalidate = false
export const fetchCache = 'auto'
export const runtime = 'nodejs'
export const preferredRegion = 'auto'
export const maxDuration = 5
```

> ✨ If you'd like this last step to happen automatically, we have a script to do this in the [FullProduct.dev](https://fullproduct.dev) ⚡️ Starterkit demo [#9 plugin: GREEN-stack](https://github.com/Aetherspace/universal-app-router/pull/9).

## 💡 Improving it with GraphQL

This is fully optional, but pairing this pattern with something like GraphQL (e.g. [#5 plugin: Apollo GraphQL](https://github.com/Aetherspace/universal-app-router/pull/5)) is actually a great combo, because:

- ✅ You can create executable GraphQL schemas
- ✅ Meaning you can execute the same query during SSR, CSR (Web) and on Mobile (iOS & Android)

This is one of the reasons I recommend GraphQL for fetching data in Universal apps. We recommend you create or use some universal GraphQL fetcher together with [graphql.tada](https://gql-tada.0no.co/get-started/#a-demo-in-128-seconds) 🪄

---

🚀 We've perfected this Universal Data Fetching pattern in the [FullProduct.dev](https://fullproduct.dev) ⚡️ Starterkit. 

> Demo 👉 [#9 plugin: GREEN-stack](https://github.com/Aetherspace/universal-app-router/pull/9)

---

### Official `@tanstack/react-query` docs

https://tanstack.com/query/latest/docs/framework/react/overview
