### PR TITLE
plugin: Turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ yarn-error.log*
 .pnp.js
 
 # -- @end @expo/next-adapter --
+
+.turbo

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "features/*",
         "packages/*"
       ],
+      "devDependencies": {
+        "turbo": "^1.13.2"
+      },
       "engines": {
         "node": ">=18.19.1"
       }
@@ -15457,10 +15460,105 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
+    "node_modules/turbo": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
+      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
+      "dev": true,
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "1.13.4",
+        "turbo-darwin-arm64": "1.13.4",
+        "turbo-linux-64": "1.13.4",
+        "turbo-linux-arm64": "1.13.4",
+        "turbo-windows-64": "1.13.4",
+        "turbo-windows-arm64": "1.13.4"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
+      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
+      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
+      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
+      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/turbo-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.2.0.tgz",
       "integrity": "sha512-FKFg7A0To1VU4CH9YmSMON5QphK0BXjSoiC7D9yMh+mEEbXLUP9qJ4hEt1qcjKtzncs1OpcnjZO8NgrlVbZH+g=="
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
+      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
+      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,20 @@
     "next": "~14.0.4"
   },
   "scripts": {
-    "dev": "npm run dev:web & npm run dev:mobile",
-    "dev:web": "npm -w @app/next run dev",
-    "dev:mobile": "npm -w @app/expo run dev",
-    "android": "npm -w @app/expo run android",
-    "ios": "npm -w @app/expo run ios",
-    "expo:web": "npm -w @app/expo run web",
-    "build": "npm -w @app/next run build",
-    "add-dependencies": "npm -w @app/expo run add-dependencies",
-    "env:local": "npm -w @app/next run env:local & npm -w @app/expo run env:local"
+    "dev": "npx turbo run dev",
+    "dev:web": "npx turbo run @app/next#dev",
+    "dev:mobile": "npx turbo run @app/expo#dev",
+    "android": "npx turbo run android",
+    "ios": "npx turbo run ios",
+    "expo:web": "npx turbo run @app/expo#web",
+    "build": "npx turbo run build",
+    "add-dependencies": "npx turbo run @app-expo#add-dependencies",
+    "env:local": "npx turbo run env:local",
+    "turbo:login": "npx turbo login",
+    "turbo:link": "npx turbo link",
+    "turbo:unlink": "npx turbo unlink"
+  },
+  "devDependencies": {
+    "turbo": "^1.13.2"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://turbo.build/schema.json",
+    "pipeline": {
+        "build": {
+            "outputs": [".next/**", "!.next/cache/**"],
+            "cache": true
+        },
+        "dev": {
+            "cache": false
+        },
+        "@app/next#dev": {
+            "cache": false
+        },
+        "@app/expo#dev": {
+            "cache": false
+        },
+        "android": {
+            "cache": false
+        },
+        "ios": {
+            "cache": false
+        },
+        "@app/expo#web": {
+            "cache": false
+        },
+        "@app-expo#add-dependencies": {
+            "cache": false
+        },
+        "env:local": {
+            "cache": false
+        }
+    }
+}


### PR DESCRIPTION
## Plugin features when merged

- [x] Set up your monorepo tasks with [turborepo](https://turbo.build/repo) for essential monorepo tooling

## Enable Remote task runner cache

```zsh
npm run turbo:login
npm run turbo:link
```

> A major key 🔑 to Turborepo's speed is that it is both lazy and efficient—it does the least amount of work possible and it tries to never redo work that's already been done before. At the moment, Turborepo caches your tasks on your local filesystem (i.e. "single-player mode," if you will). What if there was a way to teleport and share a single cache across machines? Almost like a "Dropbox" for your Turborepo cache.

> https://turbo.build/repo/docs/getting-started/existing-monorepo#using-remote-caching-for-local-development

## Official Turborepo Docs

https://turbo.build/repo
